### PR TITLE
Add message bus and shared AgentContext

### DIFF
--- a/context.js
+++ b/context.js
@@ -1,0 +1,32 @@
+/**
+ * Shared agent context used across the system.
+ */
+export class AgentContext {
+    constructor() {
+        this.goal_id = null;
+        this.hasNewGoal = false;
+        this.readyToPlan = false;
+        this.planReady = false;
+        this.step_cnt = 0;
+        this.goalDone = false;
+        this.needReplan = false;
+        this.inventory = {};
+    }
+
+    /**
+     * Factory to create a context from an initial goal payload.
+     * @param {object} goal_payload
+     * @returns {AgentContext}
+     */
+    static fromInitialGoal(goal_payload) {
+        const ctx = new AgentContext();
+        if (goal_payload) {
+            ctx.goal_id = goal_payload.goal_id ?? null;
+            if (goal_payload.inventory) {
+                ctx.inventory = { ...goal_payload.inventory };
+            }
+        }
+        ctx.hasNewGoal = true;
+        return ctx;
+    }
+}

--- a/messageBus.js
+++ b/messageBus.js
@@ -1,0 +1,24 @@
+import { EventEmitter } from 'events';
+
+/**
+ * Singleton event bus used for simple Pub/Sub communication.
+ */
+export const bus = new EventEmitter();
+
+/**
+ * Publish a payload on the given topic.
+ * @param {string} topic
+ * @param {any} payload
+ */
+export function publish(topic, payload) {
+    bus.emit(topic, payload);
+}
+
+/**
+ * Subscribe to a topic with the provided handler.
+ * @param {string} topic
+ * @param {(payload: any) => void} handler
+ */
+export function subscribe(topic, handler) {
+    bus.on(topic, handler);
+}


### PR DESCRIPTION
## Summary
- implement a simple Pub/Sub message bus
- add `AgentContext` class for storing goal state

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686e0b25d37483268ea3149997495c50